### PR TITLE
Fixes Open Contact Page

### DIFF
--- a/src/hooks/windows/use-rps-sketch-window.ts
+++ b/src/hooks/windows/use-rps-sketch-window.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import { useRPSSketchState } from '../rps/use-rps-sketch-state';
 import type { NavBarMenuParent, WindowIDs, RPSWindowState } from '../../types';
-import { GH_NEW_ISSUES, MAILTO } from '../../consts/urls';
+import { GH_NEW_ISSUES } from '../../consts/urls';
 
 /**
  * Custom hook for managing the Rock, Paper, Scissors sketch window state and functionality
@@ -227,9 +227,9 @@ export function useRPSSketchWindow(): RPSWindowState {
 						{
 							key: 'contact',
 							titleText: 'Contact',
-							hoverExplainer: 'Send @horaciovelvetine an email',
+							hoverExplainer: 'Open the Contact window to get in touch',
 							onClickAction: () => {
-								window.open(MAILTO);
+								openWindowByID('contact-window');
 							},
 							displayMenuBreakAfter: true,
 						},
@@ -260,7 +260,7 @@ export function useRPSSketchWindow(): RPSWindowState {
 				},
 			];
 		},
-		[closeWindowCallback, isShown, sketchState]
+		[closeWindowCallback, isFocused, isShown, sketchState]
 	);
 
 	return {

--- a/src/hooks/windows/use-solvedoku-window.ts
+++ b/src/hooks/windows/use-solvedoku-window.ts
@@ -6,7 +6,7 @@ import type {
 	PuzzleDifficulty,
 } from '../../types';
 import { useSolvedokuGameState } from '../solvedoku/use-solvedoku-game-state';
-import { GH_NEW_ISSUES, MAILTO } from '../../consts/urls';
+import { GH_NEW_ISSUES } from '../../consts/urls';
 
 /**
  * Custom hook for managing the Solvedoku window state and functionality
@@ -68,7 +68,7 @@ export function useSolvedokuWindow(): SolvedokuWindowState {
 							onClickAction: () => {
 								openWindowByID('solvedoku-window');
 							},
-							displayMenuBreakAfter: true
+							displayMenuBreakAfter: true,
 						},
 						{
 							key: 'solvedoku-settings',
@@ -218,9 +218,9 @@ export function useSolvedokuWindow(): SolvedokuWindowState {
 						{
 							key: 'contact',
 							titleText: 'Contact',
-							hoverExplainer: 'Send @horaciovelvetine an email',
+							hoverExplainer: 'Open the Contact window to get in touch',
 							onClickAction: () => {
-								window.open(MAILTO);
+								openWindowByID('contact-window');
 							},
 							displayMenuBreakAfter: true,
 						},


### PR DESCRIPTION
dropdown menus from rps and solvedoku now open the contact window instead of the email direct link

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Help > Contact in RPS and Solvedoku now opens the in-app `contact-window` rather than an email link.
> 
> - **Windows Hooks**:
>   - **Help > Contact**: Switch `onClickAction` to `openWindowByID('contact-window')` in `use-rps-sketch-window.ts` and `use-solvedoku-window.ts`; update hover text accordingly.
>   - **Imports**: Remove `MAILTO` usage; retain `GH_NEW_ISSUES` in both files.
>   - **RPS**: Add `isFocused` to `navBarMenuItems` `useCallback` dependency array to reflect focus state in menu disable logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56592e8f988109af2bd18353f27007efd5bf9f9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->