### PR TITLE
Fix Missed Changes

### DIFF
--- a/src/features/devsktop/components/dock-bar/dock-bar.tsx
+++ b/src/features/devsktop/components/dock-bar/dock-bar.tsx
@@ -35,7 +35,7 @@ export function DockBar({ windowManager, siteSettings }: DockBarProps) {
 						label='Home'
 						Icon={HomeIcon}
 						onClick={() => {
-							windowManager.openWindowByID('main-landing-window');
+							windowManager.openWindowByID('landing-page-window');
 						}}
 						isOpen={windowManager.mainLandingWindow.isShown}
 						siteSettings={siteSettings}
@@ -62,7 +62,7 @@ export function DockBar({ windowManager, siteSettings }: DockBarProps) {
 						label='Writing'
 						Icon={NotesIcon}
 						onClick={() => {
-							windowManager.openWindowByID("writing-window");
+							windowManager.openWindowByID('writing-window');
 						}}
 						isOpen={windowManager.writingWindow.isShown}
 						siteSettings={siteSettings}

--- a/src/hooks/windows/use-rps-sketch-window.ts
+++ b/src/hooks/windows/use-rps-sketch-window.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import { useRPSSketchState } from '../rps/use-rps-sketch-state';
 import type { NavBarMenuParent, WindowIDs, RPSWindowState } from '../../types';
-import { GH_NEW_ISSUES, MAILTO } from '../../consts/urls';
+import { GH_NEW_ISSUES } from '../../consts/urls';
 
 /**
  * Custom hook for managing the Rock, Paper, Scissors sketch window state and functionality
@@ -227,9 +227,9 @@ export function useRPSSketchWindow(): RPSWindowState {
 						{
 							key: 'contact',
 							titleText: 'Contact',
-							hoverExplainer: 'Send @horaciovelvetine an email',
+							hoverExplainer: 'Open the Contact window to get in touch',
 							onClickAction: () => {
-								window.open(MAILTO);
+								openWindowByID('contact-window');
 							},
 							displayMenuBreakAfter: true,
 						},
@@ -260,7 +260,7 @@ export function useRPSSketchWindow(): RPSWindowState {
 				},
 			];
 		},
-		[closeWindowCallback, isShown, sketchState]
+		[closeWindowCallback, isFocused, isShown, sketchState]
 	);
 
 	return {

--- a/src/hooks/windows/use-solvedoku-window.ts
+++ b/src/hooks/windows/use-solvedoku-window.ts
@@ -6,7 +6,7 @@ import type {
 	PuzzleDifficulty,
 } from '../../types';
 import { useSolvedokuGameState } from '../solvedoku/use-solvedoku-game-state';
-import { GH_NEW_ISSUES, MAILTO } from '../../consts/urls';
+import { GH_NEW_ISSUES } from '../../consts/urls';
 
 /**
  * Custom hook for managing the Solvedoku window state and functionality
@@ -68,7 +68,7 @@ export function useSolvedokuWindow(): SolvedokuWindowState {
 							onClickAction: () => {
 								openWindowByID('solvedoku-window');
 							},
-							displayMenuBreakAfter: true
+							displayMenuBreakAfter: true,
 						},
 						{
 							key: 'solvedoku-settings',
@@ -218,9 +218,9 @@ export function useSolvedokuWindow(): SolvedokuWindowState {
 						{
 							key: 'contact',
 							titleText: 'Contact',
-							hoverExplainer: 'Send @horaciovelvetine an email',
+							hoverExplainer: 'Open the Contact window to get in touch',
 							onClickAction: () => {
-								window.open(MAILTO);
+								openWindowByID('contact-window');
 							},
 							displayMenuBreakAfter: true,
 						},

--- a/src/routes/projects/the-wikiverse.tsx
+++ b/src/routes/projects/the-wikiverse.tsx
@@ -56,7 +56,6 @@ function TheWikiverseProjectPage() {
 
 	// Determine if we have no posts at all vs no search result
 	const activeSearch = postSearch.trim() !== '';
-	const tagSelected = selectedTags.length !== 0;
 
 	return (
 		<div className='min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 p-4 sm:p-6 lg:p-8'>
@@ -116,7 +115,7 @@ function TheWikiverseProjectPage() {
 										posts={devLogPosts}
 										activeSearch={activeSearch}
 										siteSettings={siteSettings}
-										tagSelected={tagSelected}
+										selectedTags={selectedTags}
 										setSelectedTags={setSelectedTags}
 									/>
 								</div>


### PR DESCRIPTION
- Solvedoku and RPS windows now open the contact window instead of the email directly to link

- Wikiverse mobile project page passes selectedTags state to the post list display as intended

- Fixes dockbar reference to changeg WindowID value for the landing page iwndow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Contact menu opens the contact window instead of email, Wikiverse dev-log passes selectedTags to PostListDisplay, and DockBar Home points to landing-page-window.
> 
> - **Windows**:
>   - **Help > Contact**: RPS and Solvedoku now open `contact-window` (removed `MAILTO`); updated hover text.
>   - **RPS hook**: Updated `navBarMenuItems` deps to include `isFocused`.
> - **Projects**:
>   - **Wikiverse page**: Passes `selectedTags` to `PostListDisplay` (removed `tagSelected`).
> - **UI**:
>   - **DockBar**: Home opens `landing-page-window`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d9f88b82f75894f5fedeefc90952eccae784a74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->